### PR TITLE
Update smearing initialization to avoid nans in masked systems

### DIFF
--- a/jaxpme/batched_mixed/batching.py
+++ b/jaxpme/batched_mixed/batching.py
@@ -92,7 +92,7 @@ def get_batch(
     positions = np.zeros((num_atoms, 3), dtype=float)
     cell = np.zeros((num_structures, 3, 3), dtype=float)
     cell[:] = np.eye(3)
-    smearing = np.zeros(num_structures, dtype=float)
+    smearing = np.ones(num_structures, dtype=float)
     centers = np.ones(num_pairs, dtype=int) * padding_atom_idx
     others = np.ones(num_pairs, dtype=int) * padding_atom_idx
     cell_shifts = np.zeros((num_pairs, 3), dtype=int)

--- a/tests/test_batched_mixed_calculator.py
+++ b/tests/test_batched_mixed_calculator.py
@@ -24,6 +24,8 @@ def test_reference_structures(cutoff):
     atom_to_structure = sr_batch.atom_to_structure
     potentials = calculator.potentials(charges, sr_batch, nonperiodic_batch, periodic_batch)
 
+    np.testing.assert_(~np.isnan(potentials).any())
+
     E, F, S = calculator.energy_forces_stress(
         charges, sr_batch, nonperiodic_batch, periodic_batch
     )


### PR DESCRIPTION
In the current implementation, having smearing zeros to pad the system yields NaNs in k-space. A small fix is to change dummy smearings from 0 to 1