### PR TITLE
Fix k-space mask

### DIFF
--- a/jaxpme/batched_mixed/calculators.py
+++ b/jaxpme/batched_mixed/calculators.py
@@ -102,6 +102,7 @@ def Ewald(
             * batch.atom_mask
             * pbc_mask
         )
+
         return real_space + k_space
 
     def prepare_fn(atomss, cutoff, lr_wavelength=None, smearing=None):


### PR DESCRIPTION
Adding missing k-space atom mask; without it, values that should be padded get accumulated into the first masked atom