### PR TITLE
Allows having float32 for samples and batches

### DIFF
--- a/jaxpme/batched_mixed/batching.py
+++ b/jaxpme/batched_mixed/batching.py
@@ -253,7 +253,7 @@ def get_kgrid_ewald(cell, lr_wavelength):
     return np.ones((int(ns[0]), int(ns[1]), int(ns[2])))
 
 
-def to_structure(atoms, cutoff, dtype=np.float32):
+def to_structure(atoms, cutoff, dtype=np.float64):
     from vesin import ase_neighbor_list as neighbor_list
 
     structure = {}


### PR DESCRIPTION
I don’t know if it’s the cleanest way to do it. I don’t like fetching the data type from the first sample by position, but I think this does the job

Note that I fix float32 by default now