### PR TITLE
Add dtype parameter to prepare function

### DIFF
--- a/jaxpme/batched_mixed/batching.py
+++ b/jaxpme/batched_mixed/batching.py
@@ -202,8 +202,8 @@ def get_batch(
     return charges, sr_batch, nonperiodic_batch, periodic_batch
 
 
-def prepare(atoms, cutoff, lr_wavelength=None, smearing=None):
-    structure = to_structure(atoms, cutoff)
+def prepare(atoms, cutoff, lr_wavelength=None, smearing=None, dtype=np.float64):
+    structure = to_structure(atoms, cutoff, dtype=dtype)
 
     structure["charges"] = atoms.get_initial_charges()
 


### PR DESCRIPTION
In the last PR #6 I missed the fact that we should pass the dtype parameter to the prepare function so that we don’t need to hardcode it ourselves and can instead pass it through the pipeline