### PR TITLE
Use prefactor in return funciton

### DIFF
--- a/jaxpme/batched_mixed/calculators.py
+++ b/jaxpme/batched_mixed/calculators.py
@@ -107,7 +107,7 @@ def Ewald(
             * pbc_mask
         )
 
-        return real_space + k_space
+        return (real_space + k_space) * prefactor
 
     def prepare_fn(atomss, cutoff, lr_wavelength=None, smearing=None):
         from .batching import get_batch, prepare


### PR DESCRIPTION
I think we actually missed the fact that we didn’t multiply the returned potential by the prefactor, so the prefactor was effectively a dummy. This PR fixes that