### PR TITLE
Update size-finding for mixed batching

### DIFF
--- a/jaxpme/batched_mixed/batching.py
+++ b/jaxpme/batched_mixed/batching.py
@@ -291,6 +291,8 @@ def to_structure(atoms, cutoff, dtype=np.float64):
 
 
 def next_size(minimum, strategy="powers_of_2"):
+    minimum = max(minimum, 1)
+
     if isinstance(strategy, int):
         assert strategy >= minimum
         return strategy


### PR DESCRIPTION
* Change over to approach from marathon: No longer automatically add padding, that's manual, rename get_size to next_size & remove the double arguments
* Remove mandatory padding for num_atoms_pbc, num_k, num_pbc

I can't think of a reason why we should force padding for these things, but may overlook something. @E-Rum please take a look!