### PR TITLE
Tests + docs for non-PBC convention (closes #25 as not-a-bug)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ tests/
 - **Serial**: `Ewald()`, `PME()`, or `P3M()` → `.prepare()` → `.energy()/.potentials()/.energy_forces()/.energy_forces_stress()`
 - **Batched**: `jaxpme.batched_mixed.Ewald()` → `.prepare([atoms_list], cutoff)` → same methods but batched
 
+### Potential convention (matches torch-pme)
+`V_i = (1/2) Σ_{j≠i} q_j v(r_ij)` — the 1/2 is absorbed into the potential so `energy = Σ_i q_i V_i` (no extra 1/2). Both PBC and non-PBC paths (serial and batched) return this halved potential. If comparing against a textbook `V_i = Σ q_j/r_ij` reference, expect a factor of 2.
+
 ### PME vs P3M
 - **PME**: Lagrange interpolation (4-node). Faster but forces less smooth.
 - **P3M**: B-spline interpolation (n=1-5) with influence function correction. Smoother forces, better for MD.

--- a/tests/test_batched_mixed_calculator.py
+++ b/tests/test_batched_mixed_calculator.py
@@ -52,6 +52,16 @@ def test_reference_structures(cutoff):
         np.testing.assert_allclose(F[atom_to_structure == i], F2)
         np.testing.assert_allclose(S[i], S2)
 
+    # non-PBC structure: assert against halved torch-pme-convention reference
+    # V_i = (1/2) sum_{j != i} q_j / r_ij
+    nopbc_idx = len(structures)
+    q_nopbc = atoms_no_pbc.get_initial_charges()
+    r = atoms_no_pbc.get_all_distances()
+    mask = r != 0.0
+    one_over_r = np.where(mask, 1.0 / np.where(mask, r, 1.0), 0.0)
+    ref_nopbc = 0.5 * (one_over_r @ q_nopbc)
+    np.testing.assert_allclose(potentials[atom_to_structure == nopbc_idx], ref_nopbc)
+
 
 @pytest.mark.parametrize("cutoff", [4.0, 5.0, 6.0])
 def test_mixed(cutoff):
@@ -63,6 +73,9 @@ def test_mixed(cutoff):
     atoms2 = atoms.copy()
     atoms2.set_pbc(False)
 
+    # torch-pme convention: V_i = (1/2) sum_{j != i} q_j / r_ij
+    # the 1/2 is absorbed into the potential so that energy = sum_i q_i V_i
+    # (no extra 1/2 at the energy level). Both PBC and non-PBC paths use this.
     all_distances = atoms2.get_all_distances()
     mask = all_distances != 0.0
     one_over_r = np.where(mask, 1 / np.where(mask, all_distances, 1.0), 0.0)
@@ -79,6 +92,40 @@ def test_mixed(cutoff):
     )
 
     np.testing.assert_allclose(potentials[atom_to_structure == 1], reference_potentials)
+
+
+def test_nopbc_matches_large_box_pbc():
+    """Non-PBC and large-box PBC must agree: both use V_i = (1/2) sum q_j v(r_ij)."""
+    from ase import Atoms
+
+    from jaxpme.batched_mixed.calculators import Ewald
+
+    rng = np.random.default_rng(42)
+    N = 5
+    positions = rng.uniform(-3.0, 3.0, (N, 3))
+    charges = rng.normal(size=N)
+    charges -= charges.mean()
+
+    atoms_pbc = Atoms("H" * N, positions=positions, cell=[200.0] * 3, pbc=True)
+    atoms_pbc.set_initial_charges(charges)
+    atoms_nopbc = Atoms("H" * N, positions=positions, pbc=False)
+    atoms_nopbc.set_initial_charges(charges)
+
+    calc = Ewald(prefactor=1.0)
+
+    c, b, nb, pb = calc.prepare([atoms_pbc], cutoff=10.0)
+    pot_pbc = np.asarray(calc.potentials(c, b, nb, pb))[:N]
+
+    c, b, nb, pb = calc.prepare([atoms_nopbc], cutoff=10.0)
+    pot_nopbc = np.asarray(calc.potentials(c, b, nb, pb))[:N]
+
+    r = np.linalg.norm(positions[None, :] - positions[:, None], axis=-1)
+    diag = np.eye(N, dtype=bool)
+    inv_r = np.where(diag, 0.0, 1.0 / np.where(diag, 1.0, r))
+    ref_halved = 0.5 * (inv_r @ charges)
+
+    np.testing.assert_allclose(pot_nopbc, ref_halved, atol=1e-6)
+    np.testing.assert_allclose(pot_pbc, pot_nopbc, atol=1e-4)
 
 
 @pytest.mark.parametrize("cutoff", [4.0, 5.0, 6.0])

--- a/tests/test_batched_mixed_calculator.py
+++ b/tests/test_batched_mixed_calculator.py
@@ -95,7 +95,7 @@ def test_mixed(cutoff):
 
 
 def test_nopbc_matches_large_box_pbc():
-    """Non-PBC and large-box PBC must agree: both use V_i = (1/2) sum q_j v(r_ij)."""
+    """Non-PBC and large-box PBC agree: both follow V_i = (1/2) sum q_j v(r_ij)."""
     from ase import Atoms
 
     from jaxpme.batched_mixed.calculators import Ewald
@@ -106,17 +106,21 @@ def test_nopbc_matches_large_box_pbc():
     charges = rng.normal(size=N)
     charges -= charges.mean()
 
-    atoms_pbc = Atoms("H" * N, positions=positions, cell=[200.0] * 3, pbc=True)
+    # big box so PBC -> non-PBC limit is tight; cutoff controls default
+    # lr_wavelength (= cutoff/8), keeping the k-grid reasonably small
+    box, cutoff = 100.0, 15.0
+
+    atoms_pbc = Atoms("H" * N, positions=positions, cell=[box] * 3, pbc=True)
     atoms_pbc.set_initial_charges(charges)
     atoms_nopbc = Atoms("H" * N, positions=positions, pbc=False)
     atoms_nopbc.set_initial_charges(charges)
 
     calc = Ewald(prefactor=1.0)
 
-    c, b, nb, pb = calc.prepare([atoms_pbc], cutoff=10.0)
+    c, b, nb, pb = calc.prepare([atoms_pbc], cutoff=cutoff)
     pot_pbc = np.asarray(calc.potentials(c, b, nb, pb))[:N]
 
-    c, b, nb, pb = calc.prepare([atoms_nopbc], cutoff=10.0)
+    c, b, nb, pb = calc.prepare([atoms_nopbc], cutoff=cutoff)
     pot_nopbc = np.asarray(calc.potentials(c, b, nb, pb))[:N]
 
     r = np.linalg.norm(positions[None, :] - positions[:, None], axis=-1)
@@ -124,7 +128,7 @@ def test_nopbc_matches_large_box_pbc():
     inv_r = np.where(diag, 0.0, 1.0 / np.where(diag, 1.0, r))
     ref_halved = 0.5 * (inv_r @ charges)
 
-    np.testing.assert_allclose(pot_nopbc, ref_halved, atol=1e-6)
+    np.testing.assert_allclose(pot_nopbc, ref_halved)
     np.testing.assert_allclose(pot_pbc, pot_nopbc, atol=1e-4)
 
 


### PR DESCRIPTION
## Summary

Issue #25 claimed `batched_mixed.Ewald` non-PBC potentials were off by a factor of 2 vs. "physically correct". After doing the unit work, **it's not a bug** — jax-pme and torch-pme both use the halved convention `V_i = (1/2) Σ_j q_j v(r_ij)` (the 1/2 is absorbed into the potential so `energy = Σ_i q_i V_i` without an extra 1/2). The non-PBC path already matches:

| path | opposite-charge pair at r=2 in 200Å box |
|---|---|
| serial Ewald PBC | `[-0.25, +0.25]` |
| batched_mixed PBC | `[-0.25, +0.25]` |
| batched_mixed non-PBC | `[-0.25, +0.25]` |

Removing the `/2` as the issue suggested would make non-PBC 2× the PBC result and break joint PBC/non-PBC training.

Cross-checked against torch-pme's `_compute_rspace` — it also divides by 2, including for non-periodic inputs.

## What this PR does

- **No code change to `calculators.py`** — the `/2` is correct.
- `test_reference_structures`: extend the assertion loop to cover the non-PBC structure against a halved pair-sum reference. This is the gap the issue correctly identified — the non-PBC path was previously exercised but never asserted on.
- `test_nopbc_matches_large_box_pbc`: new equivalence test. A random 5-atom cluster computed with non-PBC must match the same cluster in a large PBC box. Would catch any real factor-of-2 drift between the two paths.
- `test_mixed`: add a comment naming the convention so the `/ 2` in the reference isn't mistaken for the buggy version.
- `CLAUDE.md`: document the halved torch-pme convention.

Closes #25.

## Test plan

- [x] `python -m pytest tests/ -q` → 534 passed
- [x] `ruff format . && ruff check --fix .` → clean
- [x] Manual reproducer from #25 — confirmed non-PBC matches large-box PBC (5e-6) and halved reference (2e-8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)