### PR TITLE
batched_tiled: derive real-space cutoff from num_k

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ tests/
 ## Key APIs
 - **Serial**: `Ewald()`, `PME()`, or `P3M()` → `.prepare()` → `.energy()/.potentials()/.energy_forces()/.energy_forces_stress()`
 - **Batched**: `jaxpme.batched_mixed.Ewald()` → `.prepare([atoms_list], cutoff)` → same methods but batched
-- **Tiled batched**: `jaxpme.batched_tiled.Ewald()` → `.prepare([atoms_list], num_k, cutoff)` — sum-pads atoms per system (heterogeneous-batch friendly), routes reciprocal sum through tile-dispatched XLA kernel. `num_k` is REQUIRED (no cutoff-only path).
+- **Tiled batched**: `jaxpme.batched_tiled.Ewald()` → `.prepare([atoms_list], num_k, cutoff=None)` — sum-pads atoms per system (heterogeneous-batch friendly), routes reciprocal sum through tile-dispatched XLA kernel. `num_k` is REQUIRED and fixes the k-grid; `cutoff` is optional and, when omitted, is derived from it as `lr_wavelength · 8` (mirrors `batched_mixed`).
 
 ### PME vs P3M
 - **PME**: Lagrange interpolation (4-node). Faster but forces less smooth.
@@ -48,7 +48,8 @@ The `p3m_influence()` function in `kspace.py` computes 1/U²(k) to correct for B
   handle non-PBC via bare 1/r) — see open issue for fallback
 - Power-law potentials raise `NotImplementedError` for mixed PBC corrections
 - `calculators.py` has TODO for PME/P3M parameter tuning logic
-- `batched_tiled.prepare` requires `num_k` (no cutoff-only auto-derivation path)
+- `batched_tiled.prepare` requires `num_k` (it has no cutoff-only path like
+  `batched_mixed`); `cutoff` is optional and derived from `num_k` when omitted
 
 ## 2D PBC (slab correction)
 - Supports arbitrary triclinic cells (not just orthorhombic)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ tests/
 ## Key APIs
 - **Serial**: `Ewald()`, `PME()`, or `P3M()` → `.prepare()` → `.energy()/.potentials()/.energy_forces()/.energy_forces_stress()`
 - **Batched**: `jaxpme.batched_mixed.Ewald()` → `.prepare([atoms_list], cutoff)` → same methods but batched
-- **Tiled batched**: `jaxpme.batched_tiled.Ewald()` → `.prepare([atoms_list], num_k, cutoff=None)` — sum-pads atoms per system (heterogeneous-batch friendly), routes reciprocal sum through tile-dispatched XLA kernel. `num_k` is REQUIRED and fixes the k-grid; `cutoff` is optional and, when omitted, is derived from it as `lr_wavelength · 8` (mirrors `batched_mixed`).
+- **Tiled batched**: `jaxpme.batched_tiled.Ewald()` → `.prepare([atoms_list], num_k)` — sum-pads atoms per system (heterogeneous-batch friendly), routes reciprocal sum through tile-dispatched XLA kernel. `num_k` is the single required knob: it fixes the k-grid and the real-space `cutoff` derives from it, so `cutoff` is normally omitted (pass it only to override). See README for the convention.
 
 ### PME vs P3M
 - **PME**: Lagrange interpolation (4-node). Faster but forces less smooth.
@@ -48,8 +48,7 @@ The `p3m_influence()` function in `kspace.py` computes 1/U²(k) to correct for B
   handle non-PBC via bare 1/r) — see open issue for fallback
 - Power-law potentials raise `NotImplementedError` for mixed PBC corrections
 - `calculators.py` has TODO for PME/P3M parameter tuning logic
-- `batched_tiled.prepare` requires `num_k` (it has no cutoff-only path like
-  `batched_mixed`); `cutoff` is optional and derived from `num_k` when omitted
+- `batched_tiled.prepare` requires `num_k` and has no cutoff-only path (unlike `batched_mixed`)
 
 ## 2D PBC (slab correction)
 - Supports arbitrary triclinic cells (not just orthorhombic)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ All three accept lists of `ase.Atoms` in `prepare` and handle padding/masking in
 
 `batched_tiled` is a second Ewald backend designed for heterogeneous batches: atoms are **sum-padded per system** (each system padded to `⌈N_b/BM⌉·BM` atoms, concatenated into one flat array) rather than max-padded to the batch's largest system. The reciprocal sum runs through a pure-JAX tile-dispatched kernel over fixed-size `(BM × BK)` work tiles — `vmap + segment_sum` for pass 1's structure factors, `vmap + reshape-sum` for pass 2's per-atom potential. Differentiates cleanly through autograd, including stress, with no `custom_vjp`. Trade-offs vs `batched_mixed`:
 
-- **`num_k` is required** on `prepare` (sets per-cell K target via `lr_wavelength_for_num_k`). The K axis stays rectangular across the batch, so all systems share `K_pad`; pick `num_k` once and tune Ewald α to shift work between real and reciprocal space.
+- **`num_k` is required** on `prepare` and fixes the reciprocal grid (per-cell K target via `lr_wavelength_for_num_k`; the K axis stays rectangular so all systems share `K_pad`). The real-space `cutoff` follows it: omit it and it is derived as `lr_wavelength · 8` (with `smearing = lr_wavelength · 2`), matching `batched_mixed`, so real and reciprocal space stay balanced. An explicit `cutoff` overrides only the real-space radius (`smearing` still tracks `num_k`).
 - **Tile sizes `(BM, BK)` are fixed at prepare time** (defaults `BM=32, BK=128`). They drive both the per-system atom padding and the kernel tile dimensions.
 - Lower memory and faster on heterogeneous batches where system sizes vary by a lot (small molecules + larger crystals/MOFs in the same batch).
 

--- a/jaxpme/batched_mixed/batching.py
+++ b/jaxpme/batched_mixed/batching.py
@@ -337,7 +337,15 @@ def to_structure(atoms, cutoff, dtype=np.float64):
     structure["atomic_numbers"] = atoms.get_atomic_numbers().astype(int)
     structure["charges"] = atoms.get_initial_charges().astype(dtype)
 
-    if atoms.pbc.sum() in (2, 3):
+    if cutoff is None:
+        # no neighbor list: caller handles real space without one (e.g. non-pbc
+        # bare 1/r over all pairs, where a cutoff list would be unused)
+        centers = others = np.zeros(0, dtype=int)
+        D = np.zeros((0, 3), dtype=dtype)
+        S = np.zeros((0, 3), dtype=int)
+        if (structure["cell"] == 0).all():
+            structure["cell"] = np.eye(3)
+    elif atoms.pbc.sum() in (2, 3):
         centers, others, D, S = neighbor_list("ijDS", atoms, cutoff)
     elif atoms.pbc.any():
         raise ValueError("we support: 3D pbc, 2D pbc, no pbc. received neither.")

--- a/jaxpme/batched_tiled/batching.py
+++ b/jaxpme/batched_tiled/batching.py
@@ -319,14 +319,18 @@ def get_batch(
     return charges, sr_batch, nonperiodic_batch, periodic_batch
 
 
-def prepare(atoms, num_k, cutoff, smearing=None, halfspace=True, dtype=np.float64):
+def prepare(atoms, num_k, cutoff=None, smearing=None, halfspace=True, dtype=np.float64):
     """Per-structure preprocessing.
 
-    `num_k` is required: it sets the per-cell K target via
-    `lr_wavelength_for_num_k`. Actual K_b counts vary slightly across cells
-    because of axis-rounding in `get_kgrid_ewald_shape`; the batcher max-pads
-    them to a common K_pad. `cutoff` is the real-space neighbor list radius.
-    `smearing` defaults to `lr_wavelength · 2`.
+    `num_k` fixes the reciprocal grid via `lr_wavelength_for_num_k` (K_b counts
+    vary slightly across cells from axis-rounding in `get_kgrid_ewald_shape`;
+    the batcher max-pads to a common K_pad). The real-space `cutoff` and
+    `smearing` follow it, matching `batched_mixed`: when omitted,
+    `cutoff = lr_wavelength · 8` and `smearing = lr_wavelength · 2`, keeping real
+    and reciprocal space balanced. An explicit `cutoff` overrides only the
+    real-space radius — `smearing` still tracks `num_k` — so a cutoff below
+    `lr_wavelength · 8` under-converges the real-space sum unless `smearing` is
+    pinned too.
     """
     from jaxpme.kspace import lr_wavelength_for_num_k
 
@@ -340,11 +344,16 @@ def prepare(atoms, num_k, cutoff, smearing=None, halfspace=True, dtype=np.float6
     else:
         effective_cell = cell
 
+    # num_k is always given, so lr_wavelength is always defined (not gated on pbc)
+    lr_wavelength = lr_wavelength_for_num_k(effective_cell, num_k)
+    if cutoff is None:
+        cutoff = lr_wavelength * 8.0
     if pbc.any():
-        lr_wavelength = lr_wavelength_for_num_k(effective_cell, num_k)
         if smearing is None:
             smearing = lr_wavelength * 2.0
     else:
+        # non-pbc uses bare 1/r over all pairs: smearing is unused, and the
+        # derived cutoff only sizes the masked-out neighbor list.
         lr_wavelength = None
 
     structure = to_structure(atoms, cutoff, dtype=dtype)

--- a/jaxpme/batched_tiled/batching.py
+++ b/jaxpme/batched_tiled/batching.py
@@ -344,22 +344,19 @@ def prepare(atoms, num_k, cutoff=None, smearing=None, halfspace=True, dtype=np.f
     else:
         effective_cell = cell
 
-    # num_k is always given, so lr_wavelength is always defined (not gated on pbc)
-    lr_wavelength = lr_wavelength_for_num_k(effective_cell, num_k)
-    if cutoff is None:
-        cutoff = lr_wavelength * 8.0
     if pbc.any():
+        lr_wavelength = lr_wavelength_for_num_k(effective_cell, num_k)
+        if cutoff is None:
+            cutoff = lr_wavelength * 8.0
         if smearing is None:
             smearing = lr_wavelength * 2.0
+        structure = to_structure(atoms, cutoff, dtype=dtype)
     else:
-        # non-pbc physics is bare 1/r over *all* pairs (triu_indices in to_lr),
-        # so cutoff does not affect the result here — it only feeds the vesin
-        # list in to_structure, whose pairs land in the PBC real-space term and
-        # are masked off for non-pbc atoms (it just sizes the padded pair
-        # buffer). smearing is likewise unused; None signals both.
+        # non-pbc real space is the bare 1/r sum over *all* pairs (built in
+        # to_lr), so the cutoff neighbor list would only be masked off here.
+        # Skip it (cutoff=None -> empty list) instead of carrying dead pairs.
         lr_wavelength = None
-
-    structure = to_structure(atoms, cutoff, dtype=dtype)
+        structure = to_structure(atoms, cutoff=None, dtype=dtype)
     structure["cell"] = effective_cell
 
     smearing_out, lr = to_lr(structure, lr_wavelength, smearing, halfspace=halfspace)

--- a/jaxpme/batched_tiled/batching.py
+++ b/jaxpme/batched_tiled/batching.py
@@ -352,8 +352,11 @@ def prepare(atoms, num_k, cutoff=None, smearing=None, halfspace=True, dtype=np.f
         if smearing is None:
             smearing = lr_wavelength * 2.0
     else:
-        # non-pbc uses bare 1/r over all pairs: smearing is unused, and the
-        # derived cutoff only sizes the masked-out neighbor list.
+        # non-pbc physics is bare 1/r over *all* pairs (triu_indices in to_lr),
+        # so cutoff does not affect the result here — it only feeds the vesin
+        # list in to_structure, whose pairs land in the PBC real-space term and
+        # are masked off for non-pbc atoms (it just sizes the padded pair
+        # buffer). smearing is likewise unused; None signals both.
         lr_wavelength = None
 
     structure = to_structure(atoms, cutoff, dtype=dtype)

--- a/jaxpme/batched_tiled/calculators.py
+++ b/jaxpme/batched_tiled/calculators.py
@@ -288,11 +288,13 @@ def Ewald(
     def prepare_fn(
         atomss,
         num_k,
-        cutoff,
+        cutoff=None,
         smearing=None,
         BM=32,
         BK=128,
     ):
+        # `cutoff`/`smearing` default to balanced values from `num_k`; see
+        # `batching.prepare`.
         if not halfspace:
             # full-k-space path still works; flag kept for parity with
             # batched_mixed where `num_k` was halfspace-only.

--- a/tests/test_batched_tiled_calculator.py
+++ b/tests/test_batched_tiled_calculator.py
@@ -296,6 +296,78 @@ def test_matches_batched_mixed():
     )
 
 
+@pytest.mark.parametrize("num_k", [60, 90, 150])
+def test_num_k_pathway_matches_mixed(num_k):
+    """num_k pathway: with `cutoff` omitted it must be derived from the k-grid
+    (lr_wavelength · 8), matching batched_mixed.
+
+    Every other tiled test pins `cutoff` (and `smearing`) to values already
+    balanced against `num_k`, so the derivation is never exercised. Here we pass
+    `num_k` alone on both backends; if tiled left the cutoff underived, the
+    real-space sum truncates against the num_k-derived smearing and the energies
+    drift several percent from the reference.
+    """
+    from jaxpme.batched_mixed.calculators import Ewald as MixedEwald
+    from jaxpme.batched_tiled.calculators import Ewald as TiledEwald
+
+    structures = read(REFERENCE_STRUCTURES_DIR / "coulomb_test_frames.xyz", index=":3")
+
+    ct = TiledEwald(prefactor=1.0)
+    ch_t, sr_t, nopbc_t, pbc_t = ct.prepare(structures, num_k=num_k)
+    E_t, F_t, S_t = ct.energy_forces_stress(ch_t, sr_t, nopbc_t, pbc_t)
+
+    cm = MixedEwald(prefactor=1.0)
+    ch_m, sr_m, nopbc_m, pbc_m = cm.prepare(structures, num_k=num_k)
+    E_m, F_m, S_m = cm.energy_forces_stress(ch_m, sr_m, nopbc_m, pbc_m)
+
+    np.testing.assert_allclose(
+        np.array(E_t[sr_t.structure_mask]),
+        np.array(E_m[sr_m.structure_mask]),
+        rtol=1e-10,
+    )
+    np.testing.assert_allclose(
+        np.array(F_t[sr_t.atom_mask]),
+        np.array(F_m[sr_m.atom_mask]),
+        rtol=1e-9,
+        atol=1e-15,
+    )
+    np.testing.assert_allclose(
+        np.array(S_t[sr_t.structure_mask]),
+        np.array(S_m[sr_m.structure_mask]),
+        rtol=1e-9,
+        atol=1e-15,
+    )
+
+
+def test_derived_cutoff_converges_real_space():
+    """A cutoff that follows num_k (lr_wavelength · 8) keeps the real-space sum
+    converged; a fixed cutoff decoupled from num_k does not. Locks in *why* the
+    derivation matters, not just that two backends agree.
+    """
+    from jaxpme.batched_tiled.calculators import Ewald as TiledEwald
+    from jaxpme.kspace import lr_wavelength_for_num_k
+
+    atoms = read(REFERENCE_STRUCTURES_DIR / "coulomb_test_frames.xyz", index="0")
+    num_k = 80  # coarse grid -> large smearing -> demands a large real-space cutoff
+    lr = lr_wavelength_for_num_k(atoms.get_cell().array, num_k)
+
+    calc = TiledEwald(prefactor=1.0)
+
+    def energy(cutoff):
+        ch, sr, nop, pbc = calc.prepare([atoms], num_k=num_k, cutoff=cutoff)
+        return float(
+            np.array(calc.energy(ch, sr, nop, pbc))[np.array(sr.structure_mask)][0]
+        )
+
+    e_derived = energy(None)  # cutoff = lr * 8
+    e_explicit = energy(lr * 8.0)
+    np.testing.assert_allclose(e_derived, e_explicit, rtol=1e-12)
+
+    # a plausible-looking but num_k-decoupled cutoff under-converges badly
+    e_truncated = energy(5.0)
+    assert abs(e_truncated - e_derived) / abs(e_derived) > 1e-2
+
+
 # ---------------------------------------------------------------------------
 # Helpers shared by cross-system isolation / physics invariant tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
`batched_tiled.prepare` derived `smearing` from `num_k` but took `cutoff` as a
**required, independent** argument. This breaks the num_k pathway: `num_k` fixed
the reciprocal grid *and* the smearing, but the real-space truncation was left
decoupled. With the num_k-derived smearing, a mismatched cutoff silently
under-converges the real-space erfc tail.

Reproduced vs `batched_mixed` (frame 0, `num_k=80` → `smearing=3.12`, balanced
cutoff `lr·8≈12.5`):

| tiled cutoff | rel. error vs batched_mixed |
|---|---|
| 4.0 | 5.3 % |
| 5.0 | 11.9 % |
| `lr·8` (matched) | 0 |

## Fix
Make `cutoff` optional and derive it as `lr_wavelength · 8` when omitted,
mirroring `batched_mixed`. An explicit `cutoff` still overrides (only the
real-space radius; `smearing` keeps tracking `num_k`). Num_k-only pathway now
matches `batched_mixed` bit-exactly (E/F/S), including mixed pbc/non-pbc batches.

## Why tests missed it
Every tiled test picks `num_k = _num_k_for_lr(atoms, cutoff/8)` and pins
`smearing = cutoff/4` — a hand-constructed consistent triple — and the
cross-checks feed the *same* cutoff to both backends, so a wrong-but-consistent
cutoff still agrees. Nothing exercised the num_k-only pathway.

Adds `test_num_k_pathway_matches_mixed` (num_k-only vs `batched_mixed`) and
`test_derived_cutoff_converges_real_space`. Both fail on the pre-fix source.

Docs (`README.md`, `CLAUDE.md`) updated. Full suite: 592 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)