### PR TITLE
batched prepare: don't clobber the non-PBC identity cell

### DIFF
--- a/jaxpme/batched_mixed/batching.py
+++ b/jaxpme/batched_mixed/batching.py
@@ -260,9 +260,7 @@ def prepare(
         raise ValueError("one of cutoff or num_k is required")
 
     structure = to_structure(atoms, cutoff, dtype=dtype)
-    # only periodic structures carry an effective cell; for non-PBC, keep
-    # to_structure's identity normalization (a raw zero cell would leak
-    # back in and is singular under inv() downstream)
+    # keep to_structure's identity cell for non-PBC (zero cells are singular under inv())
     if pbc.any():
         structure["cell"] = effective_cell
 

--- a/jaxpme/batched_mixed/batching.py
+++ b/jaxpme/batched_mixed/batching.py
@@ -260,7 +260,11 @@ def prepare(
         raise ValueError("one of cutoff or num_k is required")
 
     structure = to_structure(atoms, cutoff, dtype=dtype)
-    structure["cell"] = effective_cell
+    # only periodic structures carry an effective cell; for non-PBC, keep
+    # to_structure's identity normalization (a raw zero cell would leak
+    # back in and is singular under inv() downstream)
+    if pbc.any():
+        structure["cell"] = effective_cell
 
     smearing, lr = to_lr(structure, lr_wavelength, smearing, halfspace=halfspace)
 

--- a/jaxpme/batched_tiled/batching.py
+++ b/jaxpme/batched_tiled/batching.py
@@ -357,7 +357,11 @@ def prepare(atoms, num_k, cutoff=None, smearing=None, halfspace=True, dtype=np.f
         # Skip it (cutoff=None -> empty list) instead of carrying dead pairs.
         lr_wavelength = None
         structure = to_structure(atoms, cutoff=None, dtype=dtype)
-    structure["cell"] = effective_cell
+    # only periodic structures carry an effective cell; for non-PBC, keep
+    # to_structure's identity normalization (a raw zero cell would leak
+    # back in and is singular under inv() downstream)
+    if pbc.any():
+        structure["cell"] = effective_cell
 
     smearing_out, lr = to_lr(structure, lr_wavelength, smearing, halfspace=halfspace)
 

--- a/jaxpme/batched_tiled/batching.py
+++ b/jaxpme/batched_tiled/batching.py
@@ -357,9 +357,7 @@ def prepare(atoms, num_k, cutoff=None, smearing=None, halfspace=True, dtype=np.f
         # Skip it (cutoff=None -> empty list) instead of carrying dead pairs.
         lr_wavelength = None
         structure = to_structure(atoms, cutoff=None, dtype=dtype)
-    # only periodic structures carry an effective cell; for non-PBC, keep
-    # to_structure's identity normalization (a raw zero cell would leak
-    # back in and is singular under inv() downstream)
+    # keep to_structure's identity cell for non-PBC (zero cells are singular under inv())
     if pbc.any():
         structure["cell"] = effective_cell
 

--- a/tests/test_batched_mixed_batching.py
+++ b/tests/test_batched_mixed_batching.py
@@ -343,7 +343,6 @@ def test_prepare_nonpbc_keeps_identity_cell():
 
     rng = np.random.default_rng(0)
     atoms = Atoms(numbers=[1] * 4, positions=rng.uniform(0, 3.0, (4, 3)), pbc=False)
-    atoms.set_initial_charges(np.array([1.0, -1.0, 1.0, -1.0]))
 
     structure = prepare(atoms, cutoff=4.0)
     np.testing.assert_array_equal(structure["cell"], np.eye(3))

--- a/tests/test_batched_mixed_batching.py
+++ b/tests/test_batched_mixed_batching.py
@@ -330,3 +330,20 @@ def test_num_k_batching():
         nonzero = np.any(periodic_batch.k_grid[pbc_idx] != 0, axis=1).sum()
         assert nonzero >= num_k, f"structure {pbc_idx}: {nonzero} < {num_k}"
         assert nonzero < num_k * 2, f"structure {pbc_idx}: {nonzero} >> {num_k}"
+
+
+def test_prepare_nonpbc_keeps_identity_cell():
+    """prepare's effective-cell override must not clobber to_structure's
+    identity normalization for non-PBC structures with zero cells."""
+    import numpy as np
+
+    from ase import Atoms
+
+    from jaxpme.batched_mixed.batching import prepare
+
+    rng = np.random.default_rng(0)
+    atoms = Atoms(numbers=[1] * 4, positions=rng.uniform(0, 3.0, (4, 3)), pbc=False)
+    atoms.set_initial_charges(np.array([1.0, -1.0, 1.0, -1.0]))
+
+    structure = prepare(atoms, cutoff=4.0)
+    np.testing.assert_array_equal(structure["cell"], np.eye(3))

--- a/tests/test_batched_tiled_batching.py
+++ b/tests/test_batched_tiled_batching.py
@@ -159,3 +159,31 @@ def test_dispatch_table_exhaustive_coverage():
         f"  Missing: {expected - actual}\n"
         f"  Extra:   {actual - expected}"
     )
+
+
+def test_prepare_nonpbc_keeps_identity_cell():
+    """to_structure normalizes zero non-PBC cells to the identity; prepare's
+    effective-cell override must not leak the raw zeros back in (singular
+    under inv() downstream, e.g. for cells indexed by padding pbc rows)."""
+    from jaxpme.batched_tiled.batching import get_batch, prepare
+
+    rng = np.random.default_rng(0)
+    atoms = Atoms(numbers=[1] * 4, positions=rng.uniform(0, 3.0, (4, 3)), pbc=False)
+    atoms.set_initial_charges(np.array([1.0, -1.0, 1.0, -1.0]))
+
+    structure = prepare(atoms, num_k=_NUM_K, cutoff=_CUTOFF)
+    np.testing.assert_array_equal(structure["cell"], np.eye(3))
+
+    _, sr, _, _ = get_batch(
+        [structure],
+        num_structures=2,
+        num_structures_pbc=1,
+        num_atoms=8,
+        num_atoms_pbc=32,
+        num_pairs=32,
+        num_pairs_nonpbc=8,
+        num_k=128,
+        BM=32,
+        BK=128,
+    )
+    np.testing.assert_array_equal(sr.cell[0], np.eye(3))

--- a/tests/test_batched_tiled_batching.py
+++ b/tests/test_batched_tiled_batching.py
@@ -169,7 +169,6 @@ def test_prepare_nonpbc_keeps_identity_cell():
 
     rng = np.random.default_rng(0)
     atoms = Atoms(numbers=[1] * 4, positions=rng.uniform(0, 3.0, (4, 3)), pbc=False)
-    atoms.set_initial_charges(np.array([1.0, -1.0, 1.0, -1.0]))
 
     structure = prepare(atoms, num_k=_NUM_K, cutoff=_CUTOFF)
     np.testing.assert_array_equal(structure["cell"], np.eye(3))


### PR DESCRIPTION
Both batched `prepare` functions overwrite `structure["cell"]` with the raw ase cell (the effective-cell assignment for the 2D-PBC shrink logic), which clobbers `to_structure`'s own zero→identity normalization for non-PBC structures. Result: molecules carry a zero cell out of `prepare` — singular under `inv()` for any consumer that indexes cells through pbc/padding maps, and inconsistent with the convention `to_structure` itself establishes (and with `get_batch`'s identity-initialized padding cells).

Fix: apply the effective-cell override only for periodic structures. Non-PBC structures keep the identity from `to_structure`; 3D/2D behavior unchanged (for 3D the override was a no-op anyway). Regression tests in both batched suites; full suite 594 passed.

Found by iris's dict-batch alignment guard (its SR side uses pet-jax's `to_structure`, which normalizes to the identity — the shared-array equality assert flagged the disagreement on H2O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)