### PR TITLE
batched_tiled: sample_shapes, empty get_batch + explicit dtype, int_dtype

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,10 @@ jaxpme/
 │   └── batching.py     # Batch preparation utilities
 └── batched_tiled/      # Batched Ewald with sum-padded atoms + (BM, BK) tile dispatch
     ├── calculators.py  # batched_tiled.Ewald() — heterogeneous-batch backend
-    ├── batching.py     # Sum-padded layout + single (b, m_tile, k_tile) dispatch table
+    ├── batching.py     # Sum-padded layout + single (b, m_tile, k_tile) dispatch table;
+    │                   # sample_shapes() (per-sample sizing for external planners),
+    │                   # get_batch(samples=[], dtype=...) (pure-padding batches),
+    │                   # int_dtype= (NL index dtype, default int64)
     └── kernel.py       # phi_recip_xla_vmap: vmap + (segment_sum | reshape-sum) reciprocal kernel
 
 tests/

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ All three accept lists of `ase.Atoms` in `prepare` and handle padding/masking in
 - **`num_k` is required** on `prepare` and fixes the reciprocal grid (per-cell K target via `lr_wavelength_for_num_k`; the K axis stays rectangular so all systems share `K_pad`). The real-space `cutoff` follows it: omit it and it is derived as `lr_wavelength · 8` (with `smearing = lr_wavelength · 2`), matching `batched_mixed`, so real and reciprocal space stay balanced. An explicit `cutoff` overrides only the real-space radius (`smearing` still tracks `num_k`).
 - **Tile sizes `(BM, BK)` are fixed at prepare time** (defaults `BM=32, BK=128`). They drive both the per-system atom padding and the kernel tile dimensions.
 - Lower memory and faster on heterogeneous batches where system sizes vary by a lot (small molecules + larger crystals/MOFs in the same batch).
+- **Host-side batching is exposed for external pipelines**: `batched_tiled.batching.sample_shapes` gives the per-sample size accounting `get_batch` itself uses (for batch-size planners), and `get_batch(samples=[], dtype=...)` builds a pure-padding batch at explicit sizes; `int_dtype=` sets the neighbor-list index dtype (default int64).
 
 ## Development
 

--- a/jaxpme/batched_tiled/batching.py
+++ b/jaxpme/batched_tiled/batching.py
@@ -54,7 +54,33 @@ Periodic = namedtuple(
 )
 
 
-__all__ = ["Batch", "NonPeriodic", "Periodic", "get_batch", "prepare"]
+__all__ = ["Batch", "NonPeriodic", "Periodic", "get_batch", "prepare", "sample_shapes"]
+
+
+def sample_shapes(structure, BM=32):
+    """Per-sample size contributions to a `get_batch` call with tile size BM.
+
+    `get_batch`'s counting loop runs on this, so external batch-size planners
+    (accumulating samples against a budget) can rely on the same accounting.
+    Minimal valid batch sizes for a set of samples are the sums (`num_k`: max)
+    plus the reserve: +1 on `num_structures` / `num_atoms` / `num_pairs`
+    (padding structure, padding atom, guaranteed padding pair), +1 then
+    BM-rounded on `num_atoms_pbc` (i.e. exactly sum + BM), nothing on
+    `num_pairs_nonpbc` / `num_k` / `num_structures_pbc`. Note `next_size`
+    clamps its minimum to 1, so integer sizes must be >= 1 even where the
+    true need is 0.
+    """
+    lr = structure["lr"]
+    is_pbc = hasattr(lr, "k_grid")
+    n_atoms = len(structure["positions"])
+    return {
+        "n_atoms": n_atoms,
+        "n_pairs": len(structure["centers"]),
+        "is_pbc": is_pbc,
+        "n_atoms_pbc": int(np.ceil(n_atoms / BM) * BM) if is_pbc else 0,
+        "n_pairs_nonpbc": 0 if is_pbc else len(lr.centers),
+        "num_k": lr.k_grid.shape[0] if is_pbc else 0,
+    }
 
 
 def _build_dispatch_table(pbc_atom_off, n_kvec_tiles, BM):
@@ -100,6 +126,8 @@ def get_batch(
     num_k=None,
     BM=32,
     BK=128,
+    dtype=None,
+    int_dtype=int,
     strategy="powers_of_2",
 ):
     """Build a batch from `prepare`d samples.
@@ -107,13 +135,15 @@ def get_batch(
     BM, BK are tile sizes baked into the batch (Python ints). They drive both
     the per-system atom padding (`⌈N_b/BM⌉·BM`) and the K_pad alignment
     (multiple of BK). Production defaults: BM=32, BK=128.
+
+    `dtype` is the float dtype (default: inferred from `samples[0]`; required
+    explicit for `samples=[]`, which yields a pure-padding batch at the given
+    sizes). `int_dtype` is the dtype of the neighbor-list index arrays
+    (`centers`/`others`/`cell_shifts`/`*_to_structure`); the kernel-internal
+    flat-layout arrays stay int32 regardless. Per-sample accounting lives in
+    `sample_shapes` (incl. the size-reserve contract).
     """
-    _num_structures = len(samples)
-    _num_atoms = []
-    _num_pairs = []
-    _num_pairs_nonpbc = []
-    _is_pbc = []
-    _num_k = []
+    shapes = [sample_shapes(structure, BM=BM) for structure in samples]
 
     num_structures = num_structures if num_structures is not None else strategy
     num_structures_pbc = num_structures_pbc if num_structures_pbc is not None else strategy
@@ -123,28 +153,12 @@ def get_batch(
     num_pairs_nonpbc = num_pairs_nonpbc if num_pairs_nonpbc is not None else strategy
     num_k_strat = num_k if num_k is not None else strategy
 
-    for structure in samples:
-        lr = structure["lr"]
-        _num_atoms.append(len(structure["positions"]))
-        _num_pairs.append(len(structure["centers"]))
-        if hasattr(lr, "k_grid"):
-            _is_pbc.append(True)
-            _num_k.append(lr.k_grid.shape[0])
-        else:
-            _is_pbc.append(False)
-            _num_pairs_nonpbc.append(len(lr.centers))
-
-    _num_atoms = np.array(_num_atoms)
-    _num_pairs = np.array(_num_pairs)
-    _num_pairs_nonpbc = np.array(_num_pairs_nonpbc)
-    _is_pbc = np.array(_is_pbc)
-    _num_k = np.array(_num_k)
-
-    _total_atoms = int(_num_atoms.sum())
-    _total_pairs = int(_num_pairs.sum())
-    _max_k = int(_num_k.max()) if len(_num_k) > 0 else 0
-    _total_pairs_nonpbc = int(_num_pairs_nonpbc.sum()) if len(_num_pairs_nonpbc) > 0 else 0
-    _total_pbc = int(_is_pbc.sum())
+    _num_structures = len(samples)
+    _total_atoms = sum(s["n_atoms"] for s in shapes)
+    _total_pairs = sum(s["n_pairs"] for s in shapes)
+    _max_k = max((s["num_k"] for s in shapes), default=0)
+    _total_pairs_nonpbc = sum(s["n_pairs_nonpbc"] for s in shapes)
+    _total_pbc = sum(s["is_pbc"] for s in shapes)
 
     # outer sr_batch sizing (same scheme as batched_mixed)
     n_structures = next_size(_num_structures + 1, strategy=num_structures)
@@ -162,11 +176,7 @@ def get_batch(
     B_pbc_padded = max(1, next_size(_total_pbc, strategy=num_structures_pbc))
 
     # Per-pbc-system atom slots, padded to multiples of BM.
-    pbc_n_padded = []
-    for ip, structure in enumerate(samples):
-        if _is_pbc[ip]:
-            n = int(_num_atoms[ip])
-            pbc_n_padded.append(int(np.ceil(n / BM) * BM))
+    pbc_n_padded = [s["n_atoms_pbc"] for s in shapes if s["is_pbc"]]
     while len(pbc_n_padded) < B_pbc_padded:
         pbc_n_padded.append(0)
     N_pbc_total_min = int(sum(pbc_n_padded))
@@ -182,7 +192,10 @@ def get_batch(
 
     padding_atom_idx = _total_atoms
     padding_structure_idx = n_structures - 1
-    dtype = samples[0]["positions"].dtype
+    if dtype is None:
+        if not samples:
+            raise ValueError("empty `samples` requires an explicit `dtype`")
+        dtype = samples[0]["positions"].dtype
 
     # sr_batch arrays
     charges = np.zeros(n_atoms, dtype=dtype)
@@ -190,24 +203,26 @@ def get_batch(
     cell = np.zeros((n_structures, 3, 3), dtype=dtype)
     cell[:] = np.eye(3)
     smearing = np.ones(n_structures, dtype=dtype)
-    centers = np.full(n_pairs, padding_atom_idx, dtype=int)
-    others = np.full(n_pairs, padding_atom_idx, dtype=int)
-    cell_shifts = np.zeros((n_pairs, 3), dtype=int)
-    atom_to_structure = np.full(n_atoms, padding_structure_idx, dtype=int)
-    pair_to_structure = np.full(n_pairs, padding_structure_idx, dtype=int)
+    centers = np.full(n_pairs, padding_atom_idx, dtype=int_dtype)
+    others = np.full(n_pairs, padding_atom_idx, dtype=int_dtype)
+    cell_shifts = np.zeros((n_pairs, 3), dtype=int_dtype)
+    atom_to_structure = np.full(n_atoms, padding_structure_idx, dtype=int_dtype)
+    pair_to_structure = np.full(n_pairs, padding_structure_idx, dtype=int_dtype)
     structure_mask = np.zeros(n_structures, dtype=bool)
     pbc_mask = np.zeros(n_structures, dtype=bool)
     atom_mask = np.zeros(n_atoms, dtype=bool)
     pair_mask = np.zeros(n_pairs, dtype=bool)
 
     # nonperiodic
-    nonpbc_centers = np.full(n_pairs_nonpbc, padding_atom_idx, dtype=int)
-    nonpbc_others = np.full(n_pairs_nonpbc, padding_atom_idx, dtype=int)
+    nonpbc_centers = np.full(n_pairs_nonpbc, padding_atom_idx, dtype=int_dtype)
+    nonpbc_others = np.full(n_pairs_nonpbc, padding_atom_idx, dtype=int_dtype)
     nonpbc_pair_mask = np.zeros(n_pairs_nonpbc, dtype=bool)
 
     # periodic
     pbc_kgrid = np.zeros((B_pbc_padded, K_pad, 3), dtype=dtype)
-    pbc_structure_to_structure = np.full(B_pbc_padded, padding_structure_idx, dtype=int)
+    pbc_structure_to_structure = np.full(
+        B_pbc_padded, padding_structure_idx, dtype=int_dtype
+    )
     pbc_structure_mask = np.zeros(B_pbc_padded, dtype=bool)
     pbc_vectors = np.zeros((B_pbc_padded, 3), dtype=bool)
     pbc_segment_atom = np.zeros(N_pbc_total, dtype=np.int32)

--- a/tests/test_batched_tiled_batching.py
+++ b/tests/test_batched_tiled_batching.py
@@ -161,6 +161,136 @@ def test_dispatch_table_exhaustive_coverage():
     )
 
 
+# ---------------------------------------------------------------------------
+# get_batch: empty samples, dtype threading, size-reserve contract
+# ---------------------------------------------------------------------------
+
+
+def _make_random_nonpbc(n, seed=0, box=3.0):
+    rng = np.random.default_rng(seed)
+    atoms = Atoms(numbers=[1] * n, positions=rng.uniform(0, box, (n, 3)), pbc=False)
+    atoms.set_initial_charges(np.zeros(n))
+    return atoms
+
+
+_TINY_SIZES = dict(
+    num_structures=2,
+    num_structures_pbc=1,
+    num_atoms=8,
+    num_atoms_pbc=32,
+    num_pairs=16,
+    num_pairs_nonpbc=4,
+    num_k=128,
+)
+
+
+def test_get_batch_empty_samples():
+    """`samples=[]` with explicit dtype yields a pure-padding batch: identity
+    cells, all-False masks, every atom mapped to the padding structure, and
+    padding pairs at atom row 0 (`padding_atom_idx = total_atoms = 0`) —
+    masked and position-zero either way, pinned so the convention is
+    deliberate. The batch must run through the kernel and yield exact zeros."""
+    from jaxpme.batched_tiled.batching import get_batch
+    from jaxpme.batched_tiled.calculators import Ewald
+
+    charges, sr, bnp, bp = get_batch([], dtype=np.float64, **_TINY_SIZES)
+
+    np.testing.assert_array_equal(sr.cell, np.broadcast_to(np.eye(3), sr.cell.shape))
+    for mask in (
+        sr.structure_mask,
+        sr.atom_mask,
+        sr.pair_mask,
+        sr.pbc_mask,
+        bnp.pair_mask,
+        bp.structure_mask,
+        bp.pbc_atom_mask,
+    ):
+        assert not mask.any()
+    np.testing.assert_array_equal(sr.atom_to_structure, _TINY_SIZES["num_structures"] - 1)
+    np.testing.assert_array_equal(sr.centers, 0)
+    np.testing.assert_array_equal(sr.others, 0)
+    np.testing.assert_array_equal(sr.smearing, 1.0)
+
+    e = np.array(Ewald(prefactor=1.0).energy(charges, sr, bnp, bp))
+    np.testing.assert_array_equal(e, 0.0)
+
+
+def test_get_batch_empty_samples_requires_dtype():
+    from jaxpme.batched_tiled.batching import get_batch
+
+    with pytest.raises(ValueError, match="dtype"):
+        get_batch([], **_TINY_SIZES)
+
+
+def test_get_batch_int_dtype():
+    """`int_dtype` sets the NL index arrays; the kernel-internal flat-layout
+    arrays stay int32 regardless; default is int64."""
+    from jaxpme.batched_tiled.batching import get_batch, prepare
+
+    structure = prepare(_make_random_pbc(4, seed=3), num_k=_NUM_K, cutoff=_CUTOFF)
+    sizes = {**_TINY_SIZES, "num_atoms_pbc": 64, "num_pairs": 512}
+
+    _, sr, bnp, bp = get_batch([structure], int_dtype=np.int32, **sizes)
+    for arr in (
+        sr.centers,
+        sr.others,
+        sr.cell_shifts,
+        sr.atom_to_structure,
+        sr.pair_to_structure,
+        bnp.centers,
+        bnp.others,
+        bp.structure_to_structure,
+    ):
+        assert arr.dtype == np.int32
+    for arr in (bp.pbc_atom_off, bp.pbc_segment_atom, bp.pbc_to_flat, bp.dispatch_table):
+        assert arr.dtype == np.int32
+
+    _, sr64, _, _ = get_batch([structure], **sizes)
+    assert sr64.centers.dtype == np.int64
+
+
+def test_get_batch_minimal_sizes_contract():
+    """The size-reserve contract (see `sample_shapes`): `get_batch` succeeds
+    at exactly the minimal sizes and rejects anything below each axis's assert
+    boundary. `next_size` clamps its minimum to 1, so reserve-0 axes bottom
+    out at max(need, 1). `num_atoms_pbc` is BM-rounded *up* after its assert:
+    its boundary is sum(padded) + 1, and anything in [sum+1, sum+BM] lands on
+    the same final sum + BM."""
+    from jaxpme.batched_tiled.batching import get_batch, prepare, sample_shapes
+
+    BM, BK = 8, 16
+    structures = [
+        prepare(_make_random_pbc(5, seed=1), num_k=_NUM_K, cutoff=_CUTOFF),
+        prepare(_make_random_nonpbc(3, seed=2), num_k=_NUM_K, cutoff=_CUTOFF),
+    ]
+    shapes = [sample_shapes(s, BM=BM) for s in structures]
+    pbc_padded_sum = sum(s["n_atoms_pbc"] for s in shapes)
+
+    # exact assert boundary per axis (the minimum that succeeds)
+    boundary = dict(
+        num_structures=len(structures) + 1,
+        num_structures_pbc=max(sum(s["is_pbc"] for s in shapes), 1),
+        num_atoms=sum(s["n_atoms"] for s in shapes) + 1,
+        num_atoms_pbc=pbc_padded_sum + 1,
+        num_pairs=sum(s["n_pairs"] for s in shapes) + 1,
+        num_pairs_nonpbc=max(sum(s["n_pairs_nonpbc"] for s in shapes), 1),
+        num_k=max(max(s["num_k"] for s in shapes), 1),
+    )
+
+    # minimal *final* sizes (what a size planner would request)
+    minimal = {**boundary, "num_atoms_pbc": pbc_padded_sum + BM}
+    get_batch(structures, BM=BM, BK=BK, **minimal)
+
+    # the boundary itself succeeds too; num_atoms_pbc BM-rounds to sum + BM
+    _, _, _, bp = get_batch(structures, BM=BM, BK=BK, **boundary)
+    assert bp.pbc_segment_atom.shape[0] == pbc_padded_sum + BM
+
+    for axis in boundary:
+        below = {**boundary, axis: boundary[axis] - 1}
+        with pytest.raises(AssertionError):
+            get_batch(structures, BM=BM, BK=BK, **below)
+
+
 def test_prepare_nonpbc_keeps_identity_cell():
     """to_structure normalizes zero non-PBC cells to the identity; prepare's
     effective-cell override must not leak the raw zeros back in (singular


### PR DESCRIPTION
Additive host-side batching API changes for external batch planners, per the iris LR-boundary proposal (PR A of two; PR B, the raw/effective cell split, follows separately).

## Changes

- **`sample_shapes(structure, BM)`**: the per-sample size accounting `get_batch` itself now runs on — its counting loop is refactored onto this helper, so planner-side counting structurally cannot drift from the fill loop. The docstring documents the size-reserve contract (+1 on `num_structures`/`num_atoms`/`num_pairs`, +1-then-BM-round on `num_atoms_pbc`, nothing on `num_pairs_nonpbc`/`num_k`/`num_structures_pbc`, and `next_size`'s `max(minimum, 1)` clamp on reserve-0 axes).
- **`get_batch(samples=[], dtype=...)`**: empty samples now produce a pure-padding batch at the given sizes; `dtype` is required explicit in that case (otherwise still inferred from `samples[0]`). The pre-fill initialization already produces the right conventions (identity cells, all-False masks, `atom_to_structure = n_structures - 1`); the batch runs through the kernel and yields exact zeros. One wrinkle pinned deliberately: `padding_atom_idx` is 0 for an empty batch, so padding pairs point at atom row 0 (masked, zero position either way).
- **`int_dtype=`**: sets the neighbor-list index array dtype (`centers`/`others`/`cell_shifts`/`*_to_structure`), default int64 — unchanged behavior. Kernel-internal flat-layout arrays (`pbc_atom_off`/`pbc_segment_atom`/`pbc_to_flat`/`dispatch_table`) stay int32 regardless. Rationale: JAX canonicalizes int64 to int32 at placement under x64-off, so int64 batches are pure host-memory/transfer cost for fp32 pipelines.

## Tests

Four new tests in `test_batched_tiled_batching.py` (empty-batch conventions + kernel zeros, dtype requirement, int_dtype threading, minimal-sizes contract incl. the assert boundary of every axis). Full suite: **598 passed** (was 594).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgxkKJ9QyeBkQZzrc5Mc9H